### PR TITLE
fix conflict between sticky and overflow-x to allow nav to float

### DIFF
--- a/asset/sass/base/layout/_layout.scss
+++ b/asset/sass/base/layout/_layout.scss
@@ -1,4 +1,8 @@
-html, body {
+html {
+    width: 100%;
+}
+
+body {
     width: 100%;
     overflow-x: hidden;
 }

--- a/asset/sass/components/hbcu-custom/_hbcu-header-footer.scss
+++ b/asset/sass/components/hbcu-custom/_hbcu-header-footer.scss
@@ -1,6 +1,12 @@
 // HBCU Header and Footer Styles
 // Direct styles from header-footer.css to match WordPress theme
 
+.sticky-header-wrapper {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
 .site-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
This pull request introduces layout and style improvements to the base layout and HBCU header/footer components to fix the sticky navigation.

Layout:

* Split the `width: 100%` property between `html` and `body` in `_layout.scss`, and ensured `overflow-x: hidden` only applies to `body` for improved layout control.

Header/footer:

* Added a new `.sticky-header-wrapper` class with `position: sticky`, `top: 0`, and high `z-index` to keep the header visible at the top during scrolling in `_hbcu-header-footer.scss`.